### PR TITLE
fix: event calendar overflowing

### DIFF
--- a/roles/xhaintv/templates/config.js.j2
+++ b/roles/xhaintv/templates/config.js.j2
@@ -112,6 +112,7 @@ let config = {
                 marqueeLongDirections: false,
                 travelTimeToStation: 2,
                 maxReachableDepartures: 5,
+                maxUnreachableDepartures: 2,
                 fadeReachableDepartures: false
             },
         },
@@ -124,6 +125,7 @@ let config = {
                 ignoredLines: ['M10', '21'],
                 travelTimeToStation: 7,
                 maxReachableDepartures: 2,
+                maxUnreachableDepartures: 1,
                 fadeReachableDepartures: false
             },
         },


### PR DESCRIPTION
when there are actually 12 events, sometimes the event calendar overflows into the departures:

<img src="https://github.com/user-attachments/assets/0a606b8a-b39f-416c-b964-7e852430c70b" width="50%"></img>

it seems about 10 total departures can be at the bottom before things will overflow  
to ensure this, I limited the amount of unavailable departures (the ones atop that fade away), so that we end up with 10 departures total:
```
 5 available   @ Grünberger/Warschauer
 2 unavailable @ Grünberger/Warschauer
 2 available   @ U Frankfurter Tor
 1 unavailable @ U Frankfurter Tor
--------------------------------------
10
```